### PR TITLE
Fix _extract_starts bug and simplify extraction methods

### DIFF
--- a/backend/src/aerooffers/spiders/SegelflugDeSpider.py
+++ b/backend/src/aerooffers/spiders/SegelflugDeSpider.py
@@ -153,21 +153,14 @@ class SegelflugDeSpider(scrapy.Spider):
 
     def _extract_hours(self, response: Response) -> int | None:
         """Extract hours from the offer page."""
-        all_text = " ".join(response.css("::text").extract())
-
         hours_text = response.xpath('//text()[contains(., "Stunden:")]').extract_first()
-        if not hours_text:
-            # Search in all text (Stunden: might be in separate elements)
-            hours_match = re.search(r"Stunden[:\s]*(\d+)", all_text, re.IGNORECASE)
+        if hours_text:
+            hours_match = re.search(r"Stunden:\s*(\d+)", hours_text)
             if hours_match:
                 return self._extract_first_number(hours_match.group(1))
-            return None
 
-        hours_match = re.search(r"Stunden:\s*(\d+)", hours_text)
-        if hours_match:
-            return self._extract_first_number(hours_match.group(1))
-
-        # If not found in same text node, search in all text
+        # Search in all text (Stunden: might be in separate elements)
+        all_text = " ".join(response.css("::text").extract())
         hours_match = re.search(r"Stunden[:\s]*(\d+)", all_text, re.IGNORECASE)
         if hours_match:
             return self._extract_first_number(hours_match.group(1))
@@ -176,21 +169,14 @@ class SegelflugDeSpider(scrapy.Spider):
 
     def _extract_starts(self, response: Response) -> int | None:
         """Extract starts from the offer page."""
-        all_text = " ".join(response.css("::text").extract())
-
-        hours_text = response.xpath('//text()[contains(., "Stunden:")]').extract_first()
-        if not hours_text:
-            # Search in all text (they might be in separate elements)
-            starts_match = re.search(r"Starts[:\s]*(\d+)", all_text, re.IGNORECASE)
+        starts_text = response.xpath('//text()[contains(., "Starts:")]').extract_first()
+        if starts_text:
+            starts_match = re.search(r"Starts:\s*(\d+)", starts_text)
             if starts_match:
                 return self._extract_first_number(starts_match.group(1))
-            return None
 
-        starts_match = re.search(r"Starts:\s*(\d+)", hours_text)
-        if starts_match:
-            return self._extract_first_number(starts_match.group(1))
-
-        # Search in all text (they might be in separate elements)
+        # Search in all text (Starts: might be in separate elements)
+        all_text = " ".join(response.css("::text").extract())
         starts_match = re.search(r"Starts[:\s]*(\d+)", all_text, re.IGNORECASE)
         if starts_match:
             return self._extract_first_number(starts_match.group(1))


### PR DESCRIPTION
Fixes a bug in `_extract_starts` and simplifies both extraction methods.

## Bug Fix
- **Fixed**: `_extract_starts` was incorrectly searching for 'Stunden:' (hours) instead of 'Starts:'
- Changed variable name from `hours_text` to `starts_text`
- Updated XPath to search for 'Starts:' instead of 'Stunden:'

## Code Simplification
- Removed redundant fallback sections in both `_extract_hours` and `_extract_starts`
- Both methods now follow cleaner logic:
  1. Try to find text node containing the keyword
  2. If found, extract from that text node
  3. Otherwise, fallback to searching all text
  4. Return None if nothing found

## Testing
All tests pass ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bug fix**
> 
> - Corrects `\_extract_starts` to search for `"Starts:"` (instead of hours) and parse the value from the matched text node, with a fallback to full-page text.
> 
> **Simplification**
> 
> - Refactors `\_extract_hours` and `\_extract_starts` to first parse from the matching text node, then fallback to aggregated page text, removing redundant branches and clarifying variable names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45d6d5c89cb473fb3e1ed6f271248d7f1f8748eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->