### PR TITLE
Fix test results publishing permissions in backend pipeline

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -18,6 +18,10 @@ env:
 jobs:
   validate-api:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem
The `validate-api` job in the backend pipeline was failing to publish test results due to missing write permissions. The `publish-unit-test-result-action` requires `checks: write` and `pull-requests: write` permissions to create check runs and post PR comments.

## Solution
Added the required permissions block to the `validate-api` job:
- `contents: read` - to read repository contents
- `checks: write` - to create and update check runs
- `pull-requests: write` - to post test result summaries as PR comments

## Testing
This fix should allow the test results to be properly published in the GitHub Actions UI and as PR comments.