### PR TITLE
Enable Gemini LLM Classifier in Production, add classifier_name column in offers container/table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm run dev
 ```
 UI has own, detailed README.md file.
 
-Run crawlers/spiders & reclassifier:
+Run crawlers/spiders & classifier:
 ```
 cd backend
 ./run_spiders.sh && ./run_classifier.sh

--- a/backend/run_classifier_in_docker.sh
+++ b/backend/run_classifier_in_docker.sh
@@ -8,4 +8,4 @@ docker run \
   --env-file ./.env \
   $USE_LLM_CLASSIFIER \
   aerooffers-local:latest \
-  sh ./run_reclassifier.sh
+  sh ./run_classifier.sh

--- a/backend/run_reclassifier.sh
+++ b/backend/run_reclassifier.sh
@@ -2,4 +2,4 @@ export PYTHONPATH=$PYTHONPATH':./src'
 
 set -e
 
-python3 ./src/aerooffers/job_reclassify_offers.py
+python3 ./src/aerooffers/job_classify_offers.py

--- a/backend/run_reclassifier.sh
+++ b/backend/run_reclassifier.sh
@@ -1,5 +1,0 @@
-export PYTHONPATH=$PYTHONPATH':./src'
-
-set -e
-
-python3 ./src/aerooffers/job_classify_offers.py

--- a/backend/run_update_offers.sh
+++ b/backend/run_update_offers.sh
@@ -1,2 +1,2 @@
 ./run_spiders.sh
-./run_reclassifier.sh
+./run_classifier.sh

--- a/backend/src/aerooffers/classifier/classifiers.py
+++ b/backend/src/aerooffers/classifier/classifiers.py
@@ -33,6 +33,9 @@ class ClassificationResult:
 
 
 class AircraftClassifier(Protocol):
+    name: str
+    """A concise identifier for this classifier."""
+
     def classify_many(self, titles: dict[str, str]) -> dict[str, ClassificationResult]:
         """Classify multiple aircraft offer titles in batch.
 

--- a/backend/src/aerooffers/classifier/rule_based_classifier.py
+++ b/backend/src/aerooffers/classifier/rule_based_classifier.py
@@ -44,6 +44,9 @@ class RuleBasedClassifier:
     - Pattern-based normalization
     """
 
+    name: str = "rule_based"
+    """A concise identifier for this classifier."""
+
     _DEFAULT_CUTOFF_SCORE = 0.85
     _is_dg_model_re = re.compile(r"^DG[0-9]{3,4}$")
     _is_binder_model_re = re.compile(r"^(EB28|EB29)$")

--- a/backend/src/aerooffers/job_classified_offers_missing_fields.py
+++ b/backend/src/aerooffers/job_classified_offers_missing_fields.py
@@ -10,7 +10,7 @@ def unclassify_offers_missing_fields(count: int) -> int:
     """
     Unclassify offers that are classified but missing manufacturer or model.
     Only unclassifies offers without classifier_name stored in the database.
-    Sets classified flag to false for these offers so they can be reclassified.
+    Sets classified flag to false for these offers so they can be classified again.
 
     Returns:
         int: Number of offers unclassified

--- a/backend/src/aerooffers/job_classified_offers_missing_fields.py
+++ b/backend/src/aerooffers/job_classified_offers_missing_fields.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from aerooffers.my_logging import logging
@@ -6,37 +5,34 @@ from aerooffers.offers_db import get_classified_offers_missing_fields, unclassif
 
 logger = logging.getLogger("classified_offers_missing_fields_job")
 
-def unclassify_offers_missing_fields(count:int) -> int:
+
+def unclassify_offers_missing_fields(count: int) -> int:
     """
     Unclassify offers that are classified but missing manufacturer or model.
     Only unclassifies offers without classifier_name stored in the database.
     Sets classified flag to false for these offers so they can be reclassified.
-    
+
     Returns:
         int: Number of offers unclassified
     """
     offers = get_classified_offers_missing_fields(offset=0, limit=count)
-    
+
     if len(offers) == 0:
         logger.info("No classified offers missing manufacturer or model found")
         return 0
 
     logger.info(f"Unclassifying {len(offers)} offers missing manufacturer or model...")
-    
+
     unclassified_count = 0
     for offer in offers:
         offer_id = offer["id"]
         try:
             unclassify_offer(offer_id)
-            logger.info(
-                f"Unclassified offer {offer_id} with title '{offer['title']}'"
-            )
+            logger.info(f"Unclassified offer {offer_id} with title '{offer['title']}'")
             unclassified_count += 1
         except Exception as e:
-            logger.error(
-                f"Failed to unclassify offer {offer_id}: {e}"
-            )
-    
+            logger.error(f"Failed to unclassify offer {offer_id}: {e}")
+
     logger.info(f"Successfully unclassified {unclassified_count} offers")
     return unclassified_count
 
@@ -48,7 +44,7 @@ if __name__ == "__main__":
     load_dotenv(env_path, override=False)
 
     unclassify_offers_missing_fields(100)
-    #offers = get_classified_offers_missing_manufacturer_or_model()
-    #print(f"Found {len(offers)} classified offers missing manufacturer or model")
-    #for offer in offers:
+    # offers = get_classified_offers_missing_manufacturer_or_model()
+    # print(f"Found {len(offers)} classified offers missing manufacturer or model")
+    # for offer in offers:
     #    print(f"Offer ID: {offer['id']}, Title: {offer['title']}, Manufacturer: {offer.get('manufacturer')}, Model: {offer.get('model')}")

--- a/backend/src/aerooffers/job_classified_offers_missing_fields.py
+++ b/backend/src/aerooffers/job_classified_offers_missing_fields.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+
+from aerooffers.my_logging import logging
+from aerooffers.offers_db import get_classified_offers_missing_fields, unclassify_offer
+
+logger = logging.getLogger("classified_offers_missing_fields_job")
+
+def unclassify_offers_missing_fields(count:int) -> int:
+    """
+    Unclassify offers that are classified but missing manufacturer or model.
+    Only unclassifies offers without classifier_name stored in the database.
+    Sets classified flag to false for these offers so they can be reclassified.
+    
+    Returns:
+        int: Number of offers unclassified
+    """
+    offers = get_classified_offers_missing_fields(offset=0, limit=count)
+    
+    if len(offers) == 0:
+        logger.info("No classified offers missing manufacturer or model found")
+        return 0
+
+    logger.info(f"Unclassifying {len(offers)} offers missing manufacturer or model...")
+    
+    unclassified_count = 0
+    for offer in offers:
+        offer_id = offer["id"]
+        try:
+            unclassify_offer(offer_id)
+            logger.info(
+                f"Unclassified offer {offer_id} with title '{offer['title']}'"
+            )
+            unclassified_count += 1
+        except Exception as e:
+            logger.error(
+                f"Failed to unclassify offer {offer_id}: {e}"
+            )
+    
+    logger.info(f"Successfully unclassified {unclassified_count} offers")
+    return unclassified_count
+
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    env_path = Path(__file__).parent.parent.parent / ".env"
+    load_dotenv(env_path, override=False)
+
+    unclassify_offers_missing_fields(100)
+    #offers = get_classified_offers_missing_manufacturer_or_model()
+    #print(f"Found {len(offers)} classified offers missing manufacturer or model")
+    #for offer in offers:
+    #    print(f"Offer ID: {offer['id']}, Title: {offer['title']}, Manufacturer: {offer.get('manufacturer')}, Model: {offer.get('model')}")

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -166,7 +166,9 @@ def get_unclassified_offers(limit: int = 100) -> list[Any]:
     )
 
 
-def get_classified_offers_missing_fields(offset: int = 0, limit: int = 100) -> list[Any]:
+def get_classified_offers_missing_fields(
+    offset: int = 0, limit: int = 100
+) -> list[Any]:
     query = (
         "SELECT * FROM offers o "
         "WHERE o.classified = true "

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -43,6 +43,7 @@ def store_offer(
 
 def classify_offer(
     offer_id: str,
+    classifier_name: str,
     category: AircraftCategory | None = None,
     manufacturer: str | None = None,
     model: str | None = None,
@@ -51,12 +52,24 @@ def classify_offer(
         dict(op="replace", path="/classified", value=True),
         dict(op="replace", path="/manufacturer", value=manufacturer),
         dict(op="replace", path="/model", value=model),
+        dict(op="add", path="/classifier_name", value=classifier_name),
     ]
 
     if category is not None:
         operations.append(
             dict[str, Any](op="replace", path="/category", value=str(category))
         )
+
+    offers_container().patch_item(
+        partition_key=offer_id, item=offer_id, patch_operations=operations
+    )
+
+
+def unclassify_offer(offer_id: str) -> None:
+    """Set classified flag to false for an offer."""
+    operations: list[dict[str, Any]] = [
+        dict(op="replace", path="/classified", value=False),
+    ]
 
     offers_container().patch_item(
         partition_key=offer_id, item=offer_id, patch_operations=operations
@@ -72,7 +85,7 @@ def offer_url_exists(url: str) -> bool:
         )
         return next(offer, None) is not None
     except Exception as e:
-        logger.error("database error, assuming we don't have this offer already")
+        logger.error("database error, assuming we don't have this offer yet")
         logger.error(e)
         return False
 
@@ -138,9 +151,29 @@ def get_offers(
     )
 
 
-def get_unclassified_offers(offset: int = 0, limit: int = 100) -> list[Any]:
+def get_unclassified_offers(limit: int = 100) -> list[Any]:
     query = (
-        "SELECT * FROM offers o WHERE o.classified = false OFFSET @offset LIMIT @limit"
+        "SELECT * FROM offers o "
+        "WHERE o.classified = false "
+        "ORDER BY o.id ASC "
+        "OFFSET 0 LIMIT @limit"
+    )
+    params = [dict(name="@limit", value=limit)]
+    return list(
+        offers_container().query_items(
+            query=query, parameters=params, enable_cross_partition_query=True
+        )
+    )
+
+
+def get_classified_offers_missing_fields(offset: int = 0, limit: int = 100) -> list[Any]:
+    query = (
+        "SELECT * FROM offers o "
+        "WHERE o.classified = true "
+        "AND (o.manufacturer = null OR o.model = null) "
+        "AND NOT IS_DEFINED(o.classifier_name) "
+        "ORDER BY o._ts DESC "
+        "OFFSET @offset LIMIT @limit"
     )
     params = [dict(name="@offset", value=offset), dict(name="@limit", value=limit)]
     return list(
@@ -151,5 +184,5 @@ def get_unclassified_offers(offset: int = 0, limit: int = 100) -> list[Any]:
 
 
 if __name__ == "__main__":
-    print("All gliders from DB: ", get_offers(category=AircraftCategory.glider))
-    print("Unclassified offers: ", get_unclassified_offers())
+    print("First 30 gliders from DB: ", get_offers(category=AircraftCategory.glider))
+    print("First 100 unclassified offers: ", get_unclassified_offers())

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -60,7 +60,7 @@ def test_get_offers_for_given_manufacturer_and_model(api_client: FlaskClient) ->
     # given
     offer_id = offers_db.store_offer(sample_offer(price="29500", currency="EUR"))
     offers_db.classify_offer(
-        offer_id, AircraftCategory.glider, "PZL Bielsko", "SZD-9 Bocian"
+        offer_id, "Manual", AircraftCategory.glider, "PZL Bielsko", "SZD-9 Bocian"
     )
 
     # when

--- a/backend/tests/classifier/test_gemini_llm_classifiers.py
+++ b/backend/tests/classifier/test_gemini_llm_classifiers.py
@@ -27,6 +27,7 @@ def test_classify_many(mock_gemini_response: Callable[[str], MagicMock]) -> None
     titles = {
         "offer1": "Stemme S6-RT",
         "offer2": "DG 800 B",
+        "offer3": "Stemme S99",
     }
     api_response_json = json.dumps(
         [
@@ -35,6 +36,11 @@ def test_classify_many(mock_gemini_response: Callable[[str], MagicMock]) -> None
                 "manufacturer": "DG Flugzeugbau",
                 "model": "DG-800B",
                 "aircraft_type": "glider",
+            },
+            {
+                "manufacturer": "Stemme",
+                "model": "S99",
+                "aircraft_type": "tmg",
             },
         ]
     )
@@ -50,7 +56,7 @@ def test_classify_many(mock_gemini_response: Callable[[str], MagicMock]) -> None
 
     # then
     assert_that(results).is_not_none()
-    assert_that(len(results)).is_equal_to(2)
+    assert_that(len(results)).is_equal_to(3)
 
     result1 = results.get("offer1")
     assert_that(result1).is_not_none()
@@ -66,6 +72,14 @@ def test_classify_many(mock_gemini_response: Callable[[str], MagicMock]) -> None
     assert_that(result2.model).is_equal_to("DG-800B")
     assert_that(result2.aircraft_type).is_equal_to(AircraftCategory.glider)
 
+    result3 = results.get("offer3")
+    assert_that(result3).is_not_none()
+    assert result3 is not None  # Type narrowing for mypy
+    # Model "S99" is not in models.json, so it should be set to None
+    assert_that(result3.manufacturer).is_equal_to("Stemme")
+    assert_that(result3.model).is_none()
+    assert_that(result3.aircraft_type).is_equal_to(AircraftCategory.tmg)
+
 
 @pytest.mark.skip(reason="Only for exploratory testing (tweaking prompts etc.)")
 def test_using_real_gemini_api() -> None:
@@ -76,9 +90,11 @@ def test_using_real_gemini_api() -> None:
     load_dotenv(dotenv_path=env_path, override=False)
 
     active_test_cases: dict[str, str] = {
-        "1": "PEGASE 90  mint condition",
-        "2": "Diana2 FES",
-        "3": "SZD55-1 FOR SALE",
+        #"1": "PEGASE 90  mint condition",
+        #"2": "Diana2 FES",
+        #"3": "SZD55-1 FOR SALE",
+        "4": "L1-f ready to fly",
+        #"5": "Stemme S10",
     }
 
     classifier = GeminiLLMClassifier()

--- a/backend/tests/classifier/test_gemini_llm_classifiers.py
+++ b/backend/tests/classifier/test_gemini_llm_classifiers.py
@@ -90,11 +90,11 @@ def test_using_real_gemini_api() -> None:
     load_dotenv(dotenv_path=env_path, override=False)
 
     active_test_cases: dict[str, str] = {
-        #"1": "PEGASE 90  mint condition",
-        #"2": "Diana2 FES",
-        #"3": "SZD55-1 FOR SALE",
+        # "1": "PEGASE 90  mint condition",
+        # "2": "Diana2 FES",
+        # "3": "SZD55-1 FOR SALE",
         "4": "L1-f ready to fly",
-        #"5": "Stemme S10",
+        # "5": "Stemme S10",
     }
 
     classifier = GeminiLLMClassifier()

--- a/backend/tests/test_classify_offers_job.py
+++ b/backend/tests/test_classify_offers_job.py
@@ -4,7 +4,7 @@ from util import sample_offer
 
 from aerooffers import offers_db
 from aerooffers.classifier.rule_based_classifier import RuleBasedClassifier
-from aerooffers.job_reclassify_offers import reclassify_all
+from aerooffers.job_classify_offers import classify_pending
 from aerooffers.offer import AircraftCategory
 
 
@@ -15,6 +15,7 @@ def test_reclassify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     )
     offers_db.classify_offer(
         offer_id=classified_offer_id,
+        classifier_name="Manual",
         category=AircraftCategory.glider,
         manufacturer="PZL Bielsko",
         model="Bocian",
@@ -24,6 +25,7 @@ def test_reclassify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     )
     offers_db.classify_offer(
         offer_id=second_classified_offer_id,
+        classifier_name="Manual",
         category=AircraftCategory.glider,
         manufacturer="PZL Bielsko",
         model="Bocian",
@@ -31,7 +33,7 @@ def test_reclassify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     offers_db.store_offer(sample_offer(url="https://offers.com/3"))
 
     # when
-    offers_processed = reclassify_all(RuleBasedClassifier())
+    offers_processed = classify_pending(RuleBasedClassifier())
 
     # then
     assert_that(offers_processed).is_equal_to(1)
@@ -45,7 +47,7 @@ def test_should_persist_manufacturer_and_model_if_classified(
     offers_db.store_offer(sample_offer(title="LS-1"))
 
     # when
-    reclassify_all(RuleBasedClassifier())
+    classify_pending(RuleBasedClassifier())
 
     # then
     ls1_offer = offers_db.get_offers()[0]

--- a/backend/tests/test_classify_offers_job.py
+++ b/backend/tests/test_classify_offers_job.py
@@ -8,7 +8,7 @@ from aerooffers.job_classify_offers import classify_pending
 from aerooffers.offer import AircraftCategory
 
 
-def test_reclassify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
+def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     # given
     classified_offer_id = offers_db.store_offer(
         sample_offer(url="https://offers.com/1")

--- a/backend/tests/test_offers_db.py
+++ b/backend/tests/test_offers_db.py
@@ -73,7 +73,11 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
 
     # when
     offers_db.classify_offer(
-        offer_id=stored_offer_id, classifier_name="Manual", category=None, manufacturer=None, model=None
+        offer_id=stored_offer_id,
+        classifier_name="Manual",
+        category=None,
+        manufacturer=None,
+        model=None,
     )
 
     # then

--- a/backend/tests/test_offers_db.py
+++ b/backend/tests/test_offers_db.py
@@ -43,6 +43,7 @@ def test_should_filter_offers_by_manufacturer_and_model(
     stored_offer_id = offers_db.store_offer(sample_offer())
     offers_db.classify_offer(
         offer_id=stored_offer_id,
+        classifier_name="Manual",
         category=AircraftCategory.glider,
         manufacturer="Schempp-Hirth",
         model="Mini-Nimbus",
@@ -64,6 +65,7 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
     stored_offer_id = offers_db.store_offer(sample_offer())
     offers_db.classify_offer(
         offer_id=stored_offer_id,
+        classifier_name="Manual",
         category=AircraftCategory.glider,
         manufacturer="Schempp-Hirth",
         model="Mini-Nimbus",
@@ -71,7 +73,7 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
 
     # when
     offers_db.classify_offer(
-        offer_id=stored_offer_id, category=None, manufacturer=None, model=None
+        offer_id=stored_offer_id, classifier_name="Manual", category=None, manufacturer=None, model=None
     )
 
     # then

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -144,6 +144,11 @@ resource "azurerm_container_app_job" "update_offers" {
         name        = "GEMINI_API_KEY"
         secret_name = "gemini-api-key"
       }
+
+      env {
+        name  = "USE_LLM_CLASSIFIER"
+        value = "true"
+      }
     }
   }
 }


### PR DESCRIPTION
# Track Classifier Source & Enable LLM Classifier in Production

This PR enables the Gemini LLM classifier in production and adds classifier source tracking (`classifier_name` field) to all classified offers. It fixes pagination reliability issues by removing offset-based pagination and improves error handling so Gemini API failures are properly propagated instead of silently returning unknown results. Also includes a new job to unclassify legacy offers missing manufacturer/model data so they can be re-classified with the improved LLM classifier.
