### PR TITLE
Fix logging duplication and wrong spider name for new offers saved in db

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -8,6 +8,7 @@ Quick reference for non-obvious patterns and conventions.
 
 **Code**
 - Don't add comments that are obvious from the code
+- always check ruff linter and mypy rules (via `uv`) before creating PR
 
 **Tests**: 
 - Use `# given` / `# when` / `# then` structure for all tests

--- a/backend/src/aerooffers/logging.conf
+++ b/backend/src/aerooffers/logging.conf
@@ -10,6 +10,7 @@ keys=simpleFormatter
 [logger_root]
 level=INFO
 handlers=consoleHandler
+propagate=0
 
 [logger_azure]
 level=WARNING
@@ -20,6 +21,7 @@ propagate=0
 [handler_consoleHandler]
 class=StreamHandler
 formatter=simpleFormatter
+level=INFO
 args=(sys.stdout,)
 
 [formatter_simpleFormatter]

--- a/backend/src/aerooffers/my_logging.py
+++ b/backend/src/aerooffers/my_logging.py
@@ -1,6 +1,56 @@
+import logging
 import logging.config
 import os
 
 logging.config.fileConfig(
     os.path.dirname(os.path.abspath(__file__)) + os.sep + "logging.conf"
 )
+
+
+def remove_scrapy_handlers() -> None:
+    """
+    Remove handlers that Scrapy installs to prevent duplicate log messages.
+
+    Scrapy installs its own logging handlers on all loggers (not just scrapy.* ones),
+    which causes duplicate log messages when using a custom logging configuration.
+    This function:
+    1. Identifies and removes Scrapy's handler from the root logger by detecting
+       its format pattern (contains '[' and ']' brackets)
+    2. Keeps only our custom handler from logging.conf (format uses ' - ' separator)
+    3. Removes all handlers from individual loggers to ensure they propagate to root
+    4. Ensures proper propagation settings for all loggers
+
+    This should be called after creating CrawlerProcess but before starting it,
+    to catch all handlers that Scrapy might have installed during initialization.
+
+    Our custom format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    Scrapy's format: "%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+    """
+    root_logger = logging.getLogger()
+
+    # Remove Scrapy's handler from root logger by identifying it via format
+    # Our handler uses " - " separator, Scrapy's uses " [" and "] "
+    for handler in root_logger.handlers[:]:
+        if hasattr(handler, "formatter") and handler.formatter:
+            fmt = (
+                handler.formatter._fmt
+                if hasattr(handler.formatter, "_fmt")
+                else str(handler.formatter)
+            )
+            # Our format uses " - " separator, Scrapy's uses " [" and "] "
+            if " - " not in fmt or "[" in fmt:
+                # This is Scrapy's handler or an unknown handler, remove it
+                root_logger.removeHandler(handler)
+        else:
+            # Handler without formatter, remove it
+            root_logger.removeHandler(handler)
+
+    # Remove handlers from all individual loggers to ensure they propagate to root
+    # This ensures all log messages go through our single root handler
+    for logger_name in list(logging.Logger.manager.loggerDict.keys()):
+        logger_obj = logging.getLogger(logger_name)
+        # Remove all handlers so messages propagate to root
+        logger_obj.handlers = []
+        # Ensure propagation to root (except root itself and azure which has propagate=0)
+        if logger_name != "root" and not logger_name.startswith("azure"):
+            logger_obj.propagate = True

--- a/backend/src/aerooffers/my_logging.py
+++ b/backend/src/aerooffers/my_logging.py
@@ -32,11 +32,13 @@ def remove_scrapy_handlers() -> None:
     # Our handler uses " - " separator, Scrapy's uses " [" and "] "
     for handler in root_logger.handlers[:]:
         if hasattr(handler, "formatter") and handler.formatter:
-            fmt = (
-                handler.formatter._fmt
-                if hasattr(handler.formatter, "_fmt")
-                else str(handler.formatter)
-            )
+            if (
+                hasattr(handler.formatter, "_fmt")
+                and handler.formatter._fmt is not None
+            ):
+                fmt: str = handler.formatter._fmt
+            else:
+                fmt = str(handler.formatter)
             # Our format uses " - " separator, Scrapy's uses " [" and "] "
             if " - " not in fmt or "[" in fmt:
                 # This is Scrapy's handler or an unknown handler, remove it

--- a/backend/src/aerooffers/offer.py
+++ b/backend/src/aerooffers/offer.py
@@ -52,3 +52,4 @@ class Offer:
     price: OfferPrice
     manufacturer: str
     model: str
+    spider: str | None

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -9,10 +9,7 @@ from aerooffers.offer import AircraftCategory, Offer, OfferPageItem, OfferPrice
 logger = logging.getLogger("offers_db")
 
 
-def store_offer(
-    offer: OfferPageItem,
-    spider: str = "unknown",
-) -> str:
+def store_offer(offer: OfferPageItem, spider: str) -> str:
     offer_id = str(uuid.uuid4())
     offers_container().upsert_item(
         dict(
@@ -145,6 +142,7 @@ def get_offers(
                 location=db_offer["location"],
                 manufacturer=db_offer["manufacturer"],
                 model=db_offer["model"],
+                spider=db_offer.get("spider"),
             ),
             db_offers,
         )

--- a/backend/src/aerooffers/settings.py
+++ b/backend/src/aerooffers/settings.py
@@ -15,3 +15,8 @@ ITEM_PIPELINES = {
     "aerooffers.pipelines.ParsePrice": 300,
     "aerooffers.pipelines.StoreOffer": 400,
 }
+
+# Scrapy logging configuration
+# Set to INFO to prevent DEBUG messages from appearing
+# This works together with logging.conf to control log levels
+LOG_LEVEL = "INFO"

--- a/backend/src/aerooffers/spiders/SegelflugDeSpider.py
+++ b/backend/src/aerooffers/spiders/SegelflugDeSpider.py
@@ -27,7 +27,7 @@ class SegelflugDeSpider(scrapy.Spider):
 
     start_urls = [
         GLIDER_OFFERS_URL,
-        GLIDER_OFFERS_URL + "?start=48",
+        # GLIDER_OFFERS_URL + "?start=48",
         # GLIDER_OFFERS_URL + "?start=96",
         # GLIDER_OFFERS_URL + "?start=144",
         ENGINE_OFFERS_URL,
@@ -106,9 +106,7 @@ class SegelflugDeSpider(scrapy.Spider):
             else:
                 aircraft_category = AircraftCategory.glider
 
-            self._logger.debug(
-                "Adding detail page for scraping %s", ROOT_URL + detail_url
-            )
+            self._logger.debug("Adding offer for scraping %s", ROOT_URL + detail_url)
             yield scrapy.Request(
                 ROOT_URL + detail_url,
                 callback=self._parse_detail_page,

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -50,7 +50,7 @@ def test_get_offers_for_all_categories(api_client: FlaskClient) -> None:
 
 def test_get_offers_for_given_category(api_client: FlaskClient) -> None:
     # given
-    offers_db.store_offer(sample_offer())
+    offers_db.store_offer(sample_offer(), spider="test")
 
     # when & then
     assert_that(api_client.get("/api/offers?category=glider").json).is_length(1)
@@ -60,7 +60,9 @@ def test_get_offers_for_given_category(api_client: FlaskClient) -> None:
 
 def test_get_offers_for_given_manufacturer_and_model(api_client: FlaskClient) -> None:
     # given
-    offer_id = offers_db.store_offer(sample_offer(price="29500", currency="EUR"))
+    offer_id = offers_db.store_offer(
+        sample_offer(price="29500", currency="EUR"), spider="test"
+    )
     offers_db.classify_offer(
         offer_id, "Manual", AircraftCategory.glider, "PZL Bielsko", "SZD-9 Bocian"
     )
@@ -99,7 +101,7 @@ def test_get_offers_404_for_unknown_manufacturer_or_model(
     api_client: FlaskClient,
 ) -> None:
     # given
-    offers_db.store_offer(sample_offer())
+    offers_db.store_offer(sample_offer(), spider="test")
 
     # when & then
     assert_that(

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -28,7 +28,9 @@ def test_get_aircraft_models(api_client: FlaskClient) -> None:
 
 def test_get_offers_for_all_categories(api_client: FlaskClient) -> None:
     # given
-    offers_db.store_offer(sample_offer(price="29500", currency="EUR"))
+    offers_db.store_offer(
+        sample_offer(price="29500", currency="EUR"), spider="whatever"
+    )
 
     # when
     response = api_client.get("/api/offers")

--- a/backend/tests/test_classify_offers_job.py
+++ b/backend/tests/test_classify_offers_job.py
@@ -11,7 +11,7 @@ from aerooffers.offer import AircraftCategory
 def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     # given
     classified_offer_id = offers_db.store_offer(
-        sample_offer(url="https://offers.com/1")
+        sample_offer(url="https://offers.com/1"), spider="test"
     )
     offers_db.classify_offer(
         offer_id=classified_offer_id,
@@ -21,7 +21,7 @@ def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
         model="Bocian",
     )
     second_classified_offer_id = offers_db.store_offer(
-        sample_offer(url="https://offers.com/2")
+        sample_offer(url="https://offers.com/2"), spider="test"
     )
     offers_db.classify_offer(
         offer_id=second_classified_offer_id,
@@ -30,7 +30,7 @@ def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
         manufacturer="PZL Bielsko",
         model="Bocian",
     )
-    offers_db.store_offer(sample_offer(url="https://offers.com/3"))
+    offers_db.store_offer(sample_offer(url="https://offers.com/3"), spider="test")
 
     # when
     offers_processed = classify_pending(RuleBasedClassifier())
@@ -44,7 +44,7 @@ def test_should_persist_manufacturer_and_model_if_classified(
     cosmos_db: CosmosClient,
 ) -> None:
     # given
-    offers_db.store_offer(sample_offer(title="LS-1"))
+    offers_db.store_offer(sample_offer(title="LS-1"), spider="test")
 
     # when
     classify_pending(RuleBasedClassifier())

--- a/backend/tests/test_offers_db.py
+++ b/backend/tests/test_offers_db.py
@@ -10,7 +10,7 @@ from aerooffers.offer import AircraftCategory, Offer
 
 def test_should_store_and_fetch_offer(cosmos_db: CosmosClient) -> None:
     # given
-    offers_db.store_offer(sample_offer(price="29500", currency="EUR"))
+    offers_db.store_offer(sample_offer(price="29500", currency="EUR"), spider="test")
 
     # when
     all_offers = offers_db.get_offers()
@@ -25,7 +25,7 @@ def test_should_store_and_fetch_offer(cosmos_db: CosmosClient) -> None:
 
 def test_should_filter_offers_by_aircraft_type(cosmos_db: CosmosClient) -> None:
     # given
-    offers_db.store_offer(sample_offer())
+    offers_db.store_offer(sample_offer(), spider="test")
 
     # when
     gliders_only = offers_db.get_offers(category=AircraftCategory.glider)
@@ -40,7 +40,7 @@ def test_should_filter_offers_by_manufacturer_and_model(
     cosmos_db: CosmosClient,
 ) -> None:
     # given
-    stored_offer_id = offers_db.store_offer(sample_offer())
+    stored_offer_id = offers_db.store_offer(sample_offer(), spider="test")
     offers_db.classify_offer(
         offer_id=stored_offer_id,
         classifier_name="Manual",
@@ -62,7 +62,7 @@ def test_should_filter_offers_by_manufacturer_and_model(
 
 def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
     # given
-    stored_offer_id = offers_db.store_offer(sample_offer())
+    stored_offer_id = offers_db.store_offer(sample_offer(), spider="test")
     offers_db.classify_offer(
         offer_id=stored_offer_id,
         classifier_name="Manual",
@@ -87,10 +87,10 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
 
 def test_should_order_offers_by_published_date_desc(cosmos_db: CosmosClient) -> None:
     # given
-    offers_db.store_offer(sample_offer(published_at=date(2024, 1, 2)))
-    offers_db.store_offer(sample_offer(published_at=date(2024, 2, 1)))
-    offers_db.store_offer(sample_offer(published_at=date(2023, 3, 15)))
-    offers_db.store_offer(sample_offer(published_at=date(2024, 1, 31)))
+    offers_db.store_offer(sample_offer(published_at=date(2024, 1, 2)), spider="test")
+    offers_db.store_offer(sample_offer(published_at=date(2024, 2, 1)), spider="test")
+    offers_db.store_offer(sample_offer(published_at=date(2023, 3, 15)), spider="test")
+    offers_db.store_offer(sample_offer(published_at=date(2024, 1, 31)), spider="test")
 
     # when
     orders = offers_db.get_offers()
@@ -104,7 +104,7 @@ def test_should_order_offers_by_published_date_desc(cosmos_db: CosmosClient) -> 
 
 def test_should_check_url_exists(cosmos_db: CosmosClient) -> None:
     # given offer exists in db
-    offers_db.store_offer(sample_offer(url="https://offers.com/1"))
+    offers_db.store_offer(sample_offer(url="https://offers.com/1"), spider="test")
 
     # when
     url_exists = offers_db.offer_url_exists("https://offers.com/1")


### PR DESCRIPTION
## Summary

This PR addresses three issues:

1. **Fix duplicated and too-verbose logging from update_offers job**
   - Prevent Scrapy from installing its own root logging handlers
   - Remove Scrapy handlers that cause duplicate log messages
   - Adjust log levels (some info → debug) to reduce verbosity

2. **Fix `unknown` spider name when storing new offers in db**
   - Initialize `StoreOffer` pipeline via `from_crawler` to access crawler context
   - Store actual spider name with each offer instead of always using "unknown"
   - Add `spider` field to `Offer` model

3. **Fix scrapy pipeline filter's outdated signature of `process_item`**
   - Remove `spider` parameter from `process_item` to match current Scrapy API
   - Convert `PipelineFilter` from Protocol to ABC with abstract method
   - Update all pipeline implementations to use correct signature

## Test plan
- [x] All tests passing (`backend/run_tests.sh`)