### PR TITLE
Derive AircraftCategory from spider start URL

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -3,3 +3,5 @@ COSMOSDB_CREDENTIAL=??
 
 # Get your Gemini API key from: https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=???
+
+USE_LLM_CLASSIFIER=true|false

--- a/backend/src/aerooffers/classifier/classifiers.py
+++ b/backend/src/aerooffers/classifier/classifiers.py
@@ -3,19 +3,17 @@ import os
 from dataclasses import dataclass
 from typing import Protocol
 
-from aerooffers.offer import AircraftCategory
+from aerooffers.offer import UnclassifiedOffer
 
 
 @dataclass(frozen=True)
 class ClassificationResult:
     """Result of aircraft classification.
 
-    :param aircraft_type: The type of aircraft (glider, airplane, etc.) or None
     :param manufacturer: The manufacturer name or None
     :param model: The model name or None
     """
 
-    aircraft_type: AircraftCategory | None
     manufacturer: str | None
     model: str | None
 
@@ -26,7 +24,6 @@ class ClassificationResult:
         :return: ClassificationResult with all fields set to None
         """
         return cls(
-            aircraft_type=None,
             manufacturer=None,
             model=None,
         )
@@ -36,11 +33,17 @@ class AircraftClassifier(Protocol):
     name: str
     """A concise identifier for this classifier."""
 
-    def classify_many(self, titles: dict[str, str]) -> dict[str, ClassificationResult]:
+    def classify_many(
+        self,
+        offers: list[UnclassifiedOffer],
+    ) -> dict[str, ClassificationResult]:
         """Classify multiple aircraft offer titles in batch.
 
-        :param titles: Dictionary mapping identifier to title
-        :return: Dictionary mapping identifier to ClassificationResult
+        :param offers: List of UnclassifiedOffer objects to classify.
+                       Category from offers can be used to optimize search
+                       (e.g., only search glider models if category is glider).
+                       Category must not be changed/overridden by classifier.
+        :return: Dictionary mapping offer id to ClassificationResult
         """
         ...
 

--- a/backend/src/aerooffers/job_classify_offers.py
+++ b/backend/src/aerooffers/job_classify_offers.py
@@ -2,30 +2,31 @@ import os
 
 from aerooffers.classifier.classifiers import AircraftClassifier, ClassificationResult
 from aerooffers.my_logging import logging
+from aerooffers.offer import UnclassifiedOffer
 from aerooffers.offers_db import classify_offer, get_unclassified_offers
 
 logger = logging.getLogger("classify_job")
 
 
-def _classify(db_offers: list[dict], model_classifier: AircraftClassifier) -> None:
-    titles_dict = {db_offer["id"]: db_offer["title"] for db_offer in db_offers}
-
-    results = model_classifier.classify_many(titles_dict)
+def _classify(
+    unclassified_offers: list[UnclassifiedOffer], model_classifier: AircraftClassifier
+) -> None:
+    results = model_classifier.classify_many(unclassified_offers)
 
     # Process results
-    for db_offer in db_offers:
-        offer_id = db_offer["id"]
+    for offer in unclassified_offers:
+        offer_id = offer.id
         result = results.get(offer_id, ClassificationResult.unknown())
 
         if result.model is None:
             logger.warning(
-                f"No classification result for offer {offer_id} with title '{db_offer['title']}'"
+                f"No classification result for offer {offer_id} with title '{offer.title}'"
             )
         else:
             logger.info(
                 "Offer id %s with title '%s' successfully classified as '%s' '%s'",
                 offer_id,
-                db_offer["title"],
+                offer.title,
                 result.manufacturer,
                 result.model,
             )
@@ -33,7 +34,6 @@ def _classify(db_offers: list[dict], model_classifier: AircraftClassifier) -> No
         classify_offer(
             offer_id=offer_id,
             classifier_name=model_classifier.name,
-            category=result.aircraft_type,
             manufacturer=result.manufacturer,
             model=result.model,
         )
@@ -51,7 +51,7 @@ def classify_pending(model_classifier: AircraftClassifier) -> int:
 
         logger.info(f"Loaded {len(offers)} unclassified offers, calling classifier...")
 
-        _classify(db_offers=offers, model_classifier=model_classifier)
+        _classify(unclassified_offers=offers, model_classifier=model_classifier)
 
         offers_processed += len(offers)
 

--- a/backend/src/aerooffers/job_mark_failed_classifications_for_reprocessing.py
+++ b/backend/src/aerooffers/job_mark_failed_classifications_for_reprocessing.py
@@ -1,29 +1,28 @@
 """These scripts are intended to be used only from developer machine for ad-hoc one-time tasks, like data migrations etc."""
 
 from aerooffers.my_logging import logging
-from aerooffers.offers_db import get_poorly_classified_offers, unclassify_offer
+from aerooffers.offers_db import get_poorly_classified_offer_ids, unclassify_offer
 
 logger = logging.getLogger("classified_offers_missing_fields_job")
 
 
 def mark_poorly_classified_offers_for_reprocessing(count: int) -> None:
     """Unclassify offers that were poorly classified in the past by legacy rule-based classifier."""
-    offers = get_poorly_classified_offers(offset=0, limit=count)
+    offer_ids = get_poorly_classified_offer_ids(offset=0, limit=count)
 
-    if len(offers) == 0:
+    if len(offer_ids) == 0:
         logger.info("No classified offers missing manufacturer or model found")
         return
 
-    logger.info(f"Unclassifying {len(offers)} offers missing manufacturer or model...")
+    logger.info(
+        f"Unclassifying {len(offer_ids)} offers missing manufacturer or model..."
+    )
 
-    for offer in offers:
-        offer_id = offer["id"]
+    for offer_id in offer_ids:
         unclassify_offer(offer_id)
-        logger.info(
-            f"Unclassified offer {offer_id} with title '{offer['title']}', published at {offer['published_at']}"
-        )
+        logger.info(f"Unclassified offer {offer_id}")
 
-    logger.info(f"Successfully unclassified {len(offers)} offers")
+    logger.info(f"Successfully unclassified {len(offer_ids)} offers")
 
 
 if __name__ == "__main__":
@@ -31,4 +30,4 @@ if __name__ == "__main__":
 
     load_env()
 
-    mark_poorly_classified_offers_for_reprocessing(100)
+    mark_poorly_classified_offers_for_reprocessing(5)

--- a/backend/src/aerooffers/offer.py
+++ b/backend/src/aerooffers/offer.py
@@ -53,3 +53,10 @@ class Offer:
     manufacturer: str
     model: str
     spider: str | None
+
+
+@dataclass(frozen=True)
+class UnclassifiedOffer:
+    id: str
+    title: str
+    category: AircraftCategory

--- a/backend/src/aerooffers/pipelines.py
+++ b/backend/src/aerooffers/pipelines.py
@@ -106,7 +106,9 @@ class StoreOffer(OfferPipelineFilter):
 
     @override
     def process_item(self, item: OfferPageItem) -> OfferPageItem:
-        self.logger.info("Storing offer title='%s', url=%s", item.title, item.url)
+        self.logger.info(
+            "Storing '%s' offer title='%s', url=%s", item.category, item.title, item.url
+        )
 
         spider = self._crawler.spider
         if spider is not None:

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -6,7 +6,6 @@ from util import sample_offer
 
 from aerooffers import offers_db
 from aerooffers.api.flask_app import app
-from aerooffers.offer import AircraftCategory
 
 
 @pytest.fixture
@@ -63,9 +62,7 @@ def test_get_offers_for_given_manufacturer_and_model(api_client: FlaskClient) ->
     offer_id = offers_db.store_offer(
         sample_offer(price="29500", currency="EUR"), spider="test"
     )
-    offers_db.classify_offer(
-        offer_id, "Manual", AircraftCategory.glider, "PZL Bielsko", "SZD-9 Bocian"
-    )
+    offers_db.classify_offer(offer_id, "Manual", "PZL Bielsko", "SZD-9 Bocian")
 
     # when
     response = api_client.get("/api/offers/PZL Bielsko/SZD-9 Bocian")

--- a/backend/tests/classifier/test_rule_based_classifier.py
+++ b/backend/tests/classifier/test_rule_based_classifier.py
@@ -2,7 +2,7 @@ import pytest
 from assertpy import assert_that
 
 from aerooffers.classifier.rule_based_classifier import RuleBasedClassifier
-from aerooffers.offer import AircraftCategory
+from aerooffers.offer import AircraftCategory, UnclassifiedOffer
 
 classifier = RuleBasedClassifier()
 
@@ -10,142 +10,142 @@ classifier = RuleBasedClassifier()
 @pytest.mark.parametrize(
     (
         "offer_title",
+        "category",
         "expected_manufacturer",
         "expected_model",
-        "expected_aircraft_type",
     ),
     [
-        ("Stemme S6-RT", "Stemme", "S6-RT", AircraftCategory.tmg),
-        ("DG 800 B", "DG Flugzeugbau", "DG-800B", AircraftCategory.glider),
-        ("Vans Aircraft RV-6A", "Vans", "RV-6", AircraftCategory.airplane),
-        ("ASK 21 D-6854", "Alexander Schleicher", "ASK 21", AircraftCategory.glider),
-        ("ASW-24 WL", "Alexander Schleicher", "ASW 24", AircraftCategory.glider),
-        ("DG 300", "DG Flugzeugbau", "DG-300", AircraftCategory.glider),
+        ("Stemme S6-RT", AircraftCategory.tmg, "Stemme", "S6-RT"),
+        ("DG 800 B", AircraftCategory.glider, "DG Flugzeugbau", "DG-800B"),
+        ("Vans Aircraft RV-6A", AircraftCategory.airplane, "Vans", "RV-6"),
+        ("ASK 21 D-6854", AircraftCategory.glider, "Alexander Schleicher", "ASK 21"),
+        ("ASW-24 WL", AircraftCategory.glider, "Alexander Schleicher", "ASW 24"),
+        ("DG 300", AircraftCategory.glider, "DG Flugzeugbau", "DG-300"),
         (
             "TL Ultralight TL-3000 Sirius",
+            AircraftCategory.ultralight,
             "TL Ultralight",
             "TL-3000 Sirius",
-            AircraftCategory.ultralight,
         ),
-        ("Nimbus 3 25.5 m", "Schempp-Hirth", "Nimbus 3", AircraftCategory.glider),
-        ("Nimbus 3 25,5m", "Schempp-Hirth", "Nimbus 3", AircraftCategory.glider),
+        ("Nimbus 3 25.5 m", AircraftCategory.glider, "Schempp-Hirth", "Nimbus 3"),
+        ("Nimbus 3 25,5m", AircraftCategory.glider, "Schempp-Hirth", "Nimbus 3"),
         (
             "Nimbus 4DM, W-Nr. 50",
+            AircraftCategory.glider,
             "Schempp-Hirth",
             "Nimbus 4DM",
-            AircraftCategory.glider,
         ),
-        ("Ventus 2B", "Schempp-Hirth", "Ventus 2b", AircraftCategory.glider),
-        ("JS1-C", "Jonker", "JS1 C", AircraftCategory.glider),
-        # ("Cessna F-172 H ", "Cessna", "172", AircraftCategory.airplane),  # FAILING
-        ("Cessna 172 D", "Cessna", "172", AircraftCategory.airplane),
+        ("Ventus 2B", AircraftCategory.glider, "Schempp-Hirth", "Ventus 2b"),
+        ("JS1-C", AircraftCategory.glider, "Jonker", "JS1 C"),
+        # ("Cessna F-172 H ", AircraftCategory.airplane, "Cessna", "172"),  # FAILING
+        ("Cessna 172 D", AircraftCategory.airplane, "Cessna", "172"),
         (
             "Ka 6 CR-Pe - Rarität in super Zustand",
+            AircraftCategory.glider,
             "Alexander Schleicher",
             "Ka6",
-            AircraftCategory.glider,
         ),
-        # ("Piper PA-46-500TP Meridian", None, None, AircraftCategory.airplane),  # FAILING
+        # ("Piper PA-46-500TP Meridian", AircraftCategory.airplane, None, None),  # FAILING
         (
             "Grumman American AA-5 Traveler",
+            AircraftCategory.airplane,
             "Grumman American",
             "Grumman American AA-5",
-            AircraftCategory.airplane,
         ),
-        ("Club Libelle", "Glasflügel", "Club-Libelle", AircraftCategory.glider),
-        ("Tecnam P-96 Golf", "Tecnam", "P96", AircraftCategory.airplane),
-        ("ASG29E  18 M", "Alexander Schleicher", "ASG 29 E", AircraftCategory.glider),
-        # ("Mooney M20F", None, None, AircraftCategory.airplane),  # FAILING
-        ("Cessna 152", "Cessna", "152", AircraftCategory.airplane),
+        ("Club Libelle", AircraftCategory.glider, "Glasflügel", "Club-Libelle"),
+        ("Tecnam P-96 Golf", AircraftCategory.airplane, "Tecnam", "P96"),
+        ("ASG29E  18 M", AircraftCategory.glider, "Alexander Schleicher", "ASG 29 E"),
+        # ("Mooney M20F", AircraftCategory.airplane, None, None),  # FAILING
+        ("Cessna 152", AircraftCategory.airplane, "Cessna", "152"),
         # (
         #     "Eurocopter AS-365N Dauphin 2 project",
-        #     None,
-        #     None,
         #     AircraftCategory.helicopter,
+        #     None,
+        #     None,
         # ),  # FAILING
         (
             "Robin DR-315 Petit Prince",
+            AircraftCategory.airplane,
             "Robin",
             "DR315 Petit Prince",
-            AircraftCategory.airplane,
         ),
-        ("Antares 20E", "Lange", "Antares 20E", AircraftCategory.glider),
-        ("LS6a", "Rolladen Schneider", "LS6", AircraftCategory.glider),
-        # ("Pipistrel Virus SW", None, None, AircraftCategory.ultralight),  # FAILING
-        # ("Mooney M20K 252", None, None, AircraftCategory.airplane),  # FAILING
-        # ("PZL-Okecie PZL-110 Koliber 150 A", None, None, AircraftCategory.airplane),  # FAILING
-        # ("ARCUS M, MOTOR NEU", "Schempp-Hirth", "Arcus M", AircraftCategory.glider),  # FAILING
-        ("SF25 C", "Scheibe", "SF 25", AircraftCategory.tmg),
-        ("Wunderschöner G109b", "Grob", "G109b", AircraftCategory.tmg),
+        ("Antares 20E", AircraftCategory.glider, "Lange", "Antares 20E"),
+        ("LS6a", AircraftCategory.glider, "Rolladen Schneider", "LS6"),
+        # ("Pipistrel Virus SW", AircraftCategory.ultralight, None, None),  # FAILING
+        # ("Mooney M20K 252", AircraftCategory.airplane, None, None),  # FAILING
+        # ("PZL-Okecie PZL-110 Koliber 150 A", AircraftCategory.airplane, None, None),  # FAILING
+        # ("ARCUS M, MOTOR NEU", AircraftCategory.glider, "Schempp-Hirth", "Arcus M"),  # FAILING
+        ("SF25 C", AircraftCategory.tmg, "Scheibe", "SF 25"),
+        ("Wunderschöner G109b", AircraftCategory.tmg, "Grob", "G109b"),
         (
             "Ka2B with closed trailer",
+            AircraftCategory.glider,
             "Alexander Schleicher",
             "Ka2",
-            AircraftCategory.glider,
         ),
         (
             "Dg1000m engine 0h For sal",
+            AircraftCategory.glider,
             "DG Flugzeugbau",
             "DG-1000M",
-            AircraftCategory.glider,
         ),
-        ("Discus 2a", "Schempp-Hirth", "Discus 2a", AircraftCategory.glider),
-        ("LS6", "Rolladen Schneider", "LS6", AircraftCategory.glider),
-        ("DG-200", "DG Flugzeugbau", "DG-200", AircraftCategory.glider),
-        ("SZD-36A Cobra", "PZL Bielsko", "SZD-36 Cobra", AircraftCategory.glider),
-        ("ASW 15b for sale", "Alexander Schleicher", "ASW 15", AircraftCategory.glider),
-        ("L_Spatz 55 m.geschl.Hänge", "Scheibe", "L-Spatz 55", AircraftCategory.glider),
+        ("Discus 2a", AircraftCategory.glider, "Schempp-Hirth", "Discus 2a"),
+        ("LS6", AircraftCategory.glider, "Rolladen Schneider", "LS6"),
+        ("DG-200", AircraftCategory.glider, "DG Flugzeugbau", "DG-200"),
+        ("SZD-36A Cobra", AircraftCategory.glider, "PZL Bielsko", "SZD-36 Cobra"),
+        ("ASW 15b for sale", AircraftCategory.glider, "Alexander Schleicher", "ASW 15"),
+        ("L_Spatz 55 m.geschl.Hänge", AircraftCategory.glider, "Scheibe", "L-Spatz 55"),
         (
             "SZD-30 Pirat for Sale",
+            AircraftCategory.glider,
             "PZL Bielsko",
             "SZD-30 Pirat",
-            AircraftCategory.glider,
         ),
-        ("DG600M", "DG Flugzeugbau", "DG-600M", AircraftCategory.glider),
-        ("Schleicher Ka6 CR", "Alexander Schleicher", "Ka6", AircraftCategory.glider),
-        # ("AVO 68-R Samburo 100PS", None, None, AircraftCategory.glider),  # FAILING
+        ("DG600M", AircraftCategory.glider, "DG Flugzeugbau", "DG-600M"),
+        ("Schleicher Ka6 CR", AircraftCategory.glider, "Alexander Schleicher", "Ka6"),
+        # ("AVO 68-R Samburo 100PS", AircraftCategory.glider, None, None),  # FAILING
         # (
         #     "Biete Rennlibelle H 301 B",
+        #     AircraftCategory.glider,
         #     "Glasflügel",
         #     "H-301 Libelle",
-        #     AircraftCategory.glider,
         # ),  # FAILING
-        ("ASW 22 BLE", "Alexander Schleicher", "ASW 22 BLE", AircraftCategory.glider),
-        ("ASW 20 WL", "Alexander Schleicher", "ASW 20", AircraftCategory.glider),
+        ("ASW 22 BLE", AircraftCategory.glider, "Alexander Schleicher", "ASW 22 BLE"),
+        ("ASW 20 WL", AircraftCategory.glider, "Alexander Schleicher", "ASW 20"),
         (
             "ASW19b - Ultra Complete -",
+            AircraftCategory.glider,
             "Alexander Schleicher",
             "ASW 19",
-            AircraftCategory.glider,
         ),
-        # ("Std. Jantar SZD41A", None, None, AircraftCategory.glider),  # FAILING
-        # ("AS33es", "Alexander Schleicher", "AS 33", AircraftCategory.glider),  # FAILING
-        # ("LS 4-a", "Rolladen Schneider", "LS4", AircraftCategory.glider),  # FAILING
-        # ("SZD55-1 FOR SALE", "PZL Bielsko", "SZD-55-1 Promyk", AircraftCategory.glider),  # FAILING
-        ("Diana2 FES", "Avionic", "Diana 2", AircraftCategory.glider),
+        # ("Std. Jantar SZD41A", AircraftCategory.glider, None, None),  # FAILING
+        # ("AS33es", AircraftCategory.glider, "Alexander Schleicher", "AS 33"),  # FAILING
+        # ("LS 4-a", AircraftCategory.glider, "Rolladen Schneider", "LS4"),  # FAILING
+        # ("SZD55-1 FOR SALE", AircraftCategory.glider, "PZL Bielsko", "SZD-55-1 Promyk"),  # FAILING
+        ("Diana2 FES", AircraftCategory.glider, "Avionic", "Diana 2"),
         # (
         #     "Verkaufe ASH31 2018, s...",
+        #     AircraftCategory.glider,
         #     "Schempp-Hirth",
         #     "ASH 31 Mi",
-        #     AircraftCategory.glider,
         # ),  # FAILING
-        # ("HPH Shark 304 MS", "HPH", "304S SHARK", AircraftCategory.glider),  # FAILING
-        # ("Schleppen und Reisen", None, None, AircraftCategory.glider),  # FAILING
-        # ("H301 B Rennlibelle", "Glasflügel", "H-301 Libelle", AircraftCategory.glider),  # FAILING
-        # ("KA-6cr PH-321", "Alexander Schleicher", "Ka6", AircraftCategory.glider),  # FAILING
+        # ("HPH Shark 304 MS", AircraftCategory.glider, "HPH", "304S SHARK"),  # FAILING
+        # ("Schleppen und Reisen", AircraftCategory.glider, None, None),  # FAILING
+        # ("H301 B Rennlibelle", AircraftCategory.glider, "Glasflügel", "H-301 Libelle"),  # FAILING
+        # ("KA-6cr PH-321", AircraftCategory.glider, "Alexander Schleicher", "Ka6"),  # FAILING
     ],
 )
 def test_classify(
     offer_title: str,
+    category: AircraftCategory,
     expected_manufacturer: str | None,
     expected_model: str | None,
-    expected_aircraft_type: AircraftCategory,
 ) -> None:
-    results = classifier.classify_many({"test_id": offer_title})
+    offers = [UnclassifiedOffer(id="test_id", title=offer_title, category=category)]
+    results = classifier.classify_many(offers)
     result = results.get("test_id")
 
     assert_that(result).is_not_none()
     assert result is not None  # Type guard for mypy
     assert_that(result.manufacturer).is_equal_to(expected_manufacturer)
     assert_that(result.model).is_equal_to(expected_model)
-    assert_that(result.aircraft_type).is_equal_to(expected_aircraft_type)

--- a/backend/tests/spiders/test_FlugzeugMarktDeSpider.py
+++ b/backend/tests/spiders/test_FlugzeugMarktDeSpider.py
@@ -12,7 +12,8 @@ spider = FlugzeugMarktDeSpider()
 def test_collect_urls_of_all_offer_on_listing_page() -> None:
     # given
     listing_page_http_response = fake_response_from_file(
-        "spiders/samples/flugzeugmarkt_de_listing.html"
+        "spiders/samples/flugzeugmarkt_de_listing.html",
+        url="https://www.flugzeugmarkt.de/segelflugzeuge",
     )
 
     # when
@@ -32,11 +33,12 @@ def test_collect_urls_of_all_offer_on_listing_page() -> None:
 
 def test_parse_detail_page() -> None:
     # given
-    item: OfferPageItem = next(
-        spider._parse_detail_page(
-            fake_response_from_file("spiders/samples/flugzeugmarkt_de_offer.html")
-        )
+    response = fake_response_from_file(
+        "spiders/samples/flugzeugmarkt_de_offer.html",
+        url="https://www.flugzeugmarkt.de/segelflugzeuge/schempp-hirth/ventus-b/kaufen-3730.html",
     )
+    response.meta["aircraft_category"] = AircraftCategory.glider
+    item: OfferPageItem = next(spider._parse_detail_page(response))
 
     # then
     assert_that(item.title).is_equal_to("Schempp-Hirth Ventus b")

--- a/backend/tests/spiders/test_SegelflugDeSpider.py
+++ b/backend/tests/spiders/test_SegelflugDeSpider.py
@@ -12,7 +12,8 @@ spider = SegelflugDeSpider.SegelflugDeSpider()
 def test_collect_urls_of_all_offer_on_listing_page() -> None:
     # given
     listing_page_http_response = fake_response_from_file(
-        "spiders/samples/segelflug_de_listing.html"
+        "spiders/samples/segelflug_de_listing.html",
+        url="https://www.segelflug.de/index.php/de/kleinanzeigen/filterseite-de/com-djclassifieds-cat-sailplanes,5",
     )
 
     # when

--- a/backend/tests/test_classify_offers_job.py
+++ b/backend/tests/test_classify_offers_job.py
@@ -16,7 +16,6 @@ def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     offers_db.classify_offer(
         offer_id=classified_offer_id,
         classifier_name="Manual",
-        category=AircraftCategory.glider,
         manufacturer="PZL Bielsko",
         model="Bocian",
     )
@@ -26,7 +25,6 @@ def test_classify_only_unclassified_offers(cosmos_db: CosmosClient) -> None:
     offers_db.classify_offer(
         offer_id=second_classified_offer_id,
         classifier_name="Manual",
-        category=AircraftCategory.glider,
         manufacturer="PZL Bielsko",
         model="Bocian",
     )

--- a/backend/tests/test_offers_db.py
+++ b/backend/tests/test_offers_db.py
@@ -44,7 +44,6 @@ def test_should_filter_offers_by_manufacturer_and_model(
     offers_db.classify_offer(
         offer_id=stored_offer_id,
         classifier_name="Manual",
-        category=AircraftCategory.glider,
         manufacturer="Schempp-Hirth",
         model="Mini-Nimbus",
     )
@@ -66,7 +65,6 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
     offers_db.classify_offer(
         offer_id=stored_offer_id,
         classifier_name="Manual",
-        category=AircraftCategory.glider,
         manufacturer="Schempp-Hirth",
         model="Mini-Nimbus",
     )
@@ -75,7 +73,6 @@ def test_should_not_reset_category_if_none(cosmos_db: CosmosClient) -> None:
     offers_db.classify_offer(
         offer_id=stored_offer_id,
         classifier_name="Manual",
-        category=None,
         manufacturer=None,
         model=None,
     )


### PR DESCRIPTION
This PR changes how AircraftCategory is determined:

- Category is now derived from the spider start URL (listing page)
- Classification no longer overrides category (only sets manufacturer/model)
- get_unclassified_offers() now fetches only id, title, category (not page_content) for better performance