### PR TITLE
feat: Store page_content in separate CosmosDb container

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -20,3 +20,4 @@ Quick reference for non-obvious patterns and conventions.
 - Don't mention obvious things: linting fixes, test updates, pre-PR check status (expected anyway)
 - Don't include implementation details that are obvious from code
 - Don't mention temporary changes unless they're the main focus of the PR
+- When adding reasons/justifications: only include claims that are directly supported by the code changes or commit messages. Don't make assumptions about motivations (e.g., cost optimization, architectural patterns) unless explicitly stated in the code or commit

--- a/backend/src/aerooffers/db.py
+++ b/backend/src/aerooffers/db.py
@@ -83,3 +83,33 @@ def create_offers_container_if_not_exists() -> ContainerProxy:
             ],
         ),
     )
+
+
+_page_content_container: ContainerProxy | None = None
+
+
+def page_content_container() -> ContainerProxy:
+    global _page_content_container
+    if _page_content_container is not None:
+        return _page_content_container
+
+    _page_content_container = lazy_database().get_container_client(
+        container="offer_page_content"
+    )
+    return _page_content_container
+
+
+def create_page_content_container_if_not_exists() -> ContainerProxy:
+    return lazy_database().create_container_if_not_exists(
+        id="offer_page_content",
+        partition_key=PartitionKey(path="/id"),
+        offer_throughput=ThroughputProperties(
+            offer_throughput="400"
+        ),  # both containers should use less than 100 to stay under free tier limit
+        indexing_policy=dict(
+            automatic=True,
+            indexingMode=IndexingMode.Consistent,
+            includedPaths=[],
+            excludedPaths=[dict(path="/*")],
+        ),
+    )

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, UTC
 from typing import Any
 
-from aerooffers.db import offers_container
+from aerooffers.db import offers_container, page_content_container
 from aerooffers.my_logging import logging
 from aerooffers.offer import (
     AircraftCategory,
@@ -17,6 +17,8 @@ logger = logging.getLogger("offers_db")
 
 def store_offer(offer: OfferPageItem, spider: str) -> str:
     offer_id = str(uuid.uuid4())
+
+    # Store offer WITHOUT page_content
     offers_container().upsert_item(
         dict(
             id=offer_id,
@@ -35,12 +37,21 @@ def store_offer(offer: OfferPageItem, spider: str) -> str:
             location=offer.location,
             hours=offer.hours,
             starts=offer.starts,
-            page_content=offer.page_content,
+            # page_content REMOVED - stored in separate container
             classified=False,
             manufacturer=None,
             model=None,
         )
     )
+
+    # Store page_content in separate container
+    page_content_container().upsert_item(
+        dict(
+            id=offer_id,
+            page_content=offer.page_content,
+        )
+    )
+
     return offer_id
 
 

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -37,7 +37,6 @@ def store_offer(offer: OfferPageItem, spider: str) -> str:
             location=offer.location,
             hours=offer.hours,
             starts=offer.starts,
-            # page_content REMOVED - stored in separate container
             classified=False,
             manufacturer=None,
             model=None,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,9 @@
 import os
 
-from aerooffers.db import create_offers_container_if_not_exists
+from aerooffers.db import (
+    create_offers_container_if_not_exists,
+    create_page_content_container_if_not_exists,
+)
 
 os.environ["AZURE_COSMOS_EMULATOR_IMAGE"] = (
     "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20250122"
@@ -74,4 +77,10 @@ def _truncate_all_tables() -> None:
     except CosmosResourceNotFoundError:
         print("ntbd")
 
+    try:
+        lazy_database().delete_container(container="offer_page_content")
+    except CosmosResourceNotFoundError:
+        print("ntbd")
+
     create_offers_container_if_not_exists()
+    create_page_content_container_if_not_exists()

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -16,13 +16,14 @@ def sample_offer(
     location: str | None = None,
     hours: int | None = None,
     starts: int | None = None,
+    page_content: str = "<some html content>",
 ) -> OfferPageItem:
     return OfferPageItem(
         url=url,
         category=AircraftCategory.glider,
         title=title,
         published_at=published_at,
-        page_content="does not matter",
+        page_content=page_content,
         raw_price=raw_price,
         price=price,
         currency=currency,


### PR DESCRIPTION
page_content is now stored in offer_page_content container instead of offers container, reducing query payload size.

**Why?**
- **Reduced query payload size**: When querying offers for listing/display, the large HTML page_content field is not needed. By separating it into a different container, queries return only the essential offer metadata, significantly reducing data transfer.

- **Improved performance**: Smaller documents in the offers container result in faster queries and reduced latency when fetching offer lists.

- **Indexing efficiency**: The page_content container has indexing disabled (all paths excluded), which is appropriate since page content is not queried directly and reduces storage overhead.