### PR TITLE
Add Azure Storage Account infrastructure for page content migration

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,6 +9,8 @@ locals {
   cosmosdb_database_name         = "aerooffers"
   container_app_name             = "aerooffers-api"
   container_app_job_name         = "update-offers-job"
+  storage_account_name           = "aerooffers"
+  offer_pages_container_name     = "offer-pages"
 
   location = "Switzerland North"
 


### PR DESCRIPTION
Implements Phase 1 of the page content migration plan.

- Adds Azure Storage Account resource (aerooffers)
- Adds Storage Container for offer pages (offer-pages)
- Adds Storage Management Policy to archive blobs after 7 days
- Adds storage connection string secret to update_offers job
- Adds AZURE_STORAGE_CONNECTION_STRING environment variable to update_offers job
- Updates locals with storage account and container names