### PR TITLE
Migrate page content storage from CosmosDB to Azure Blob Storage

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "twisted==25.5.0",
     "azure-cosmos==4.14.5",
     "azure-identity==1.25.1",
+    "azure-storage-blob==12.28.0",
     "defusedxml==0.7.1",
     "google-genai==1.59.0",
     "python-dotenv==1.2.1",

--- a/backend/src/aerooffers/db.py
+++ b/backend/src/aerooffers/db.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from azure.cosmos import (
     ContainerProxy,
@@ -57,6 +58,11 @@ _page_content_container: ContainerProxy | None = None
 
 
 def page_content_container() -> ContainerProxy:
+    warnings.warn(
+        "page_content_container() is deprecated. Use aerooffers.page_content_storage.store_page_content() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     global _page_content_container
     if _page_content_container is not None:
         return _page_content_container

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
 
-from aerooffers.db import offers_container, page_content_container
+from aerooffers.db import offers_container
 from aerooffers.my_logging import logging
 from aerooffers.offer import (
     AircraftCategory,
@@ -13,6 +13,7 @@ from aerooffers.offer import (
     OfferPrice,
     UnclassifiedOffer,
 )
+from aerooffers.page_content_storage import store_page_content
 
 logger = logging.getLogger("offers_db")
 
@@ -50,13 +51,8 @@ def store_offer(offer: OfferPageItem, spider: str) -> str:
         )
     )
 
-    # Store page_content in separate container
-    page_content_container().upsert_item(
-        dict(
-            id=offer_id,
-            page_content=offer.page_content,
-        )
-    )
+    if offer.page_content:
+        store_page_content(offer_id, offer.page_content, offer.url)
 
     return offer_id
 

--- a/backend/src/aerooffers/page_content_storage.py
+++ b/backend/src/aerooffers/page_content_storage.py
@@ -1,0 +1,44 @@
+import os
+from datetime import datetime, UTC
+
+from azure.storage.blob import BlobServiceClient, ContentSettings
+
+from aerooffers.my_logging import logging
+
+logger = logging.getLogger("page_content_storage")
+
+_blob_service_client: BlobServiceClient | None = None
+_container_name = "offer-pages"
+
+
+def _get_blob_service_client() -> BlobServiceClient:
+    global _blob_service_client
+    if _blob_service_client is not None:
+        return _blob_service_client
+
+    connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    if not connection_string:
+        raise ValueError(
+            "AZURE_STORAGE_CONNECTION_STRING environment variable is required"
+        )
+
+    _blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+    logger.info("BlobServiceClient initialized successfully")
+    return _blob_service_client
+
+
+def store_page_content(offer_id: str, page_content: str, url: str) -> None:
+    blob_client = _get_blob_service_client().get_blob_client(
+        container=_container_name, blob=offer_id
+    )
+
+    blob_client.upload_blob(
+        data=page_content,
+        overwrite=True,
+        content_settings=ContentSettings(content_type="text/html; charset=utf-8"),
+        metadata={
+            "url": url,
+            "stored_at": datetime.now(UTC).isoformat(),
+        },
+    )
+    logger.debug(f"Stored page_content for offer_id: {offer_id}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,7 @@ os.environ["AZURE_COSMOS_EMULATOR_IMAGE"] = (
 import os
 from collections.abc import Generator
 from typing import Self
+from unittest.mock import patch
 
 import pytest
 from azure.cosmos import CosmosClient
@@ -61,6 +62,12 @@ def session_cosmos_db() -> Generator[CosmosClient, None, None]:
     yield client
 
     emulator.stop(force=True, delete_volume=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_store_page_content() -> Generator[None, None, None]:
+    with patch("aerooffers.offers_db.store_page_content"):
+        yield
 
 
 @pytest.fixture

--- a/backend/tests/test_page_content_storage.py
+++ b/backend/tests/test_page_content_storage.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from aerooffers.page_content_storage import store_page_content
+
+
+def test_should_store_page_content() -> None:
+    # given
+    offer_id = "test_offer_id"
+    page_content = "<html><body>Test content</body></html>"
+    url = "https://test.com/offer"
+
+    with patch(
+        "aerooffers.page_content_storage._get_blob_service_client"
+    ) as mock_get_client:
+        mock_blob_client = MagicMock()
+        mock_get_client.return_value.get_blob_client.return_value = mock_blob_client
+
+        # when
+        store_page_content(offer_id, page_content, url)
+
+    # then
+    mock_get_client.return_value.get_blob_client.assert_called_once_with(
+        container="offer-pages", blob=offer_id
+    )
+    mock_blob_client.upload_blob.assert_called_once()
+    call_args = mock_blob_client.upload_blob.call_args
+    assert_that(call_args.kwargs["data"]).is_equal_to(page_content)
+    assert_that(call_args.kwargs["overwrite"]).is_true()
+    assert_that(call_args.kwargs["content_settings"]["content_type"]).is_equal_to(
+        "text/html; charset=utf-8"
+    )
+    assert_that(call_args.kwargs["metadata"]["url"]).is_equal_to(url)
+    assert_that(call_args.kwargs["metadata"]).contains_key("stored_at")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -9,6 +9,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "azure-cosmos" },
     { name = "azure-identity" },
+    { name = "azure-storage-blob" },
     { name = "defusedxml" },
     { name = "flask" },
     { name = "flask-cors" },
@@ -50,6 +51,7 @@ lint = [
 requires-dist = [
     { name = "azure-cosmos", specifier = "==4.14.5" },
     { name = "azure-identity", specifier = "==1.25.1" },
+    { name = "azure-storage-blob", specifier = "==12.28.0" },
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "flask", specifier = "==3.1.2" },
     { name = "flask-cors", specifier = "==6.0.2" },
@@ -174,6 +176,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", size = 279826, upload-time = "2025-10-06T20:30:02.194Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", size = 191317, upload-time = "2025-10-06T20:30:04.251Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/24/072ba8e27b0e2d8fec401e9969b429d4f5fc4c8d4f0f05f4661e11f7234a/azure_storage_blob-12.28.0.tar.gz", hash = "sha256:e7d98ea108258d29aa0efbfd591b2e2075fa1722a2fae8699f0b3c9de11eff41", size = 604225, upload-time = "2026-01-06T23:48:57.282Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/3a/6ef2047a072e54e1142718d433d50e9514c999a58f51abfff7902f3a72f8/azure_storage_blob-12.28.0-py3-none-any.whl", hash = "sha256:00fb1db28bf6a7b7ecaa48e3b1d5c83bfadacc5a678b77826081304bd87d6461", size = 431499, upload-time = "2026-01-06T23:48:58.995Z" },
 ]
 
 [[package]]
@@ -670,6 +687,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements Phase 2 of the page content migration plan.

- Adds azure-storage-blob dependency
- Creates page_content_storage module with blob storage functions
- Updates offers_db to use blob storage instead of CosmosDB for page_content
- Adds deprecation warning to page_content_container function (kept for migration script compatibility)
- Updates tests to mock blob storage calls
- Adds unit tests for page_content_storage module

All tests pass. The page_content_container function is kept temporarily for the migration script (Phase 3) and will be removed in Phase 5 after migration is complete.