### PR TITLE
Remove deprecated page_content CosmosDB code

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -5,3 +5,6 @@ COSMOSDB_CREDENTIAL=??
 GEMINI_API_KEY=???
 
 USE_LLM_CLASSIFIER=true|false
+
+# for storing offer html pages. Go to Azure Portal → Storage Accounts → aerooffers → Access keys", copy the "Connection string" value (either key1 or key2)
+AZURE_STORAGE_CONNECTION_STRING=??

--- a/backend/src/aerooffers/db.py
+++ b/backend/src/aerooffers/db.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 from azure.cosmos import (
     ContainerProxy,
@@ -52,22 +51,3 @@ def offers_container() -> ContainerProxy:
 
     _offers_container = lazy_database().get_container_client(container="offers")
     return _offers_container
-
-
-_page_content_container: ContainerProxy | None = None
-
-
-def page_content_container() -> ContainerProxy:
-    warnings.warn(
-        "page_content_container() is deprecated. Use aerooffers.page_content_storage.store_page_content() instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    global _page_content_container
-    if _page_content_container is not None:
-        return _page_content_container
-
-    _page_content_container = lazy_database().get_container_client(
-        container="offer_page_content"
-    )
-    return _page_content_container

--- a/backend/src/aerooffers/page_content_storage.py
+++ b/backend/src/aerooffers/page_content_storage.py
@@ -28,17 +28,20 @@ def _get_blob_service_client() -> BlobServiceClient:
 
 
 def store_page_content(offer_id: str, page_content: str, url: str) -> None:
-    blob_client = _get_blob_service_client().get_blob_client(
-        container=_container_name, blob=offer_id
-    )
+    try:
+        blob_client = _get_blob_service_client().get_blob_client(
+            container=_container_name, blob=offer_id
+        )
 
-    blob_client.upload_blob(
-        data=page_content,
-        overwrite=True,
-        content_settings=ContentSettings(content_type="text/html; charset=utf-8"),
-        metadata={
-            "url": url,
-            "stored_at": datetime.now(UTC).isoformat(),
-        },
-    )
-    logger.debug(f"Stored page_content for offer_id: {offer_id}")
+        blob_client.upload_blob(
+            data=page_content,
+            overwrite=True,
+            content_settings=ContentSettings(content_type="text/html; charset=utf-8"),
+            metadata={
+                "url": url,
+                "stored_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        logger.debug(f"Stored page_content for offer_id: {offer_id}")
+    except Exception as e:
+        logger.error(f"Could not upload page content for offer {offer_id}", e)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,6 @@
 import os
 
-from util import (
-    create_offers_container_if_not_exists,
-    create_page_content_container_if_not_exists,
-)
+from util import create_offers_container_if_not_exists
 
 os.environ["AZURE_COSMOS_EMULATOR_IMAGE"] = (
     "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20250122"
@@ -84,10 +81,4 @@ def _truncate_all_tables() -> None:
     except CosmosResourceNotFoundError:
         print("ntbd")
 
-    try:
-        lazy_database().delete_container(container="offer_page_content")
-    except CosmosResourceNotFoundError:
-        print("ntbd")
-
     create_offers_container_if_not_exists()
-    create_page_content_container_if_not_exists()

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -102,19 +102,3 @@ def create_offers_container_if_not_exists() -> ContainerProxy:
             ],
         ),
     )
-
-
-def create_page_content_container_if_not_exists() -> ContainerProxy:
-    return lazy_database().create_container_if_not_exists(
-        id="offer_page_content",
-        partition_key=PartitionKey(path="/id"),
-        offer_throughput=ThroughputProperties(
-            offer_throughput="400"
-        ),  # both containers should use less than 100 to stay under free tier limit
-        indexing_policy=dict(
-            automatic=True,
-            indexingMode=IndexingMode.Consistent,
-            includedPaths=[],
-            excludedPaths=[dict(path="/*")],
-        ),
-    )


### PR DESCRIPTION
# Remove deprecated page_content CosmosDB code

Removes deprecated code and migration artifacts after page content migration to Azure Blob Storage.

## Changes

- Remove `page_content_container()` from `db.py`
- Remove migration script and design docs
- Fix connection string handling in `page_content_storage.py`
- Remove test utilities for CosmosDB page_content container
- Add `AZURE_STORAGE_CONNECTION_STRING` to `.env.template`
