### PR TITLE
refactor: move page content storage to pipeline and url_to_id to domain

### DIFF
--- a/backend/src/aerooffers/offer.py
+++ b/backend/src/aerooffers/offer.py
@@ -1,3 +1,4 @@
+import hashlib
 from dataclasses import dataclass
 from datetime import date
 from enum import auto, StrEnum
@@ -60,3 +61,8 @@ class UnclassifiedOffer:
     id: str
     title: str
     category: AircraftCategory
+
+
+def url_to_id(url: str) -> str:
+    """Generate a deterministic ID from a URL using SHA-256 hash."""
+    return hashlib.sha256(url.encode()).hexdigest()

--- a/backend/src/aerooffers/offer.py
+++ b/backend/src/aerooffers/offer.py
@@ -64,5 +64,14 @@ class UnclassifiedOffer:
 
 
 def url_to_id(url: str) -> str:
-    """Generate a deterministic ID from a URL using SHA-256 hash."""
+    """
+    Generate a deterministic ID from a URL using SHA-256 hash.
+
+    This ID is used as the primary identifier in:
+    - Cosmos DB offers container (as the document ID)
+    - Azure Blob Storage (as the blob name for page content)
+
+    The deterministic nature ensures the same URL always produces the same ID,
+    enabling efficient lookups and preventing duplicates.
+    """
     return hashlib.sha256(url.encode()).hexdigest()

--- a/backend/src/aerooffers/offers_db.py
+++ b/backend/src/aerooffers/offers_db.py
@@ -1,4 +1,3 @@
-import hashlib
 from datetime import datetime, UTC
 from typing import Any
 
@@ -12,19 +11,14 @@ from aerooffers.offer import (
     OfferPageItem,
     OfferPrice,
     UnclassifiedOffer,
+    url_to_id,
 )
-from aerooffers.page_content_storage import store_page_content
 
 logger = logging.getLogger("offers_db")
 
 
-def _url_to_id(url: str) -> str:
-    """Generate a deterministic ID from a URL using SHA-256 hash."""
-    return hashlib.sha256(url.encode()).hexdigest()
-
-
 def store_offer(offer: OfferPageItem, spider: str) -> str:
-    offer_id = _url_to_id(offer.url)
+    offer_id = url_to_id(offer.url)
 
     # Store offer WITHOUT page_content
     offers_container().upsert_item(
@@ -50,9 +44,6 @@ def store_offer(offer: OfferPageItem, spider: str) -> str:
             model=None,
         )
     )
-
-    if offer.page_content:
-        store_page_content(offer_id, offer.page_content, offer.url)
 
     return offer_id
 
@@ -92,7 +83,7 @@ def offer_url_exists(url: str) -> bool:
     Uses a deterministic ID derived from the URL for optimal performance.
     """
     try:
-        offer_id = _url_to_id(url)
+        offer_id = url_to_id(url)
         offers_container().read_item(item=offer_id, partition_key=offer_id)
         return True
     except CosmosResourceNotFoundError:

--- a/backend/src/aerooffers/pipelines.py
+++ b/backend/src/aerooffers/pipelines.py
@@ -9,6 +9,7 @@ from aerooffers.fx import to_price_in_euro
 from aerooffers.my_logging import logging
 from aerooffers.offer import OfferPageItem
 from aerooffers.offers_db import store_offer
+from aerooffers.page_content_storage import store_page_content
 
 
 class OfferPipelineFilter(ABC):
@@ -99,5 +100,10 @@ class StoreOffer(OfferPipelineFilter):
         else:
             spider_name = "unknown"
 
-        store_offer(offer=item, spider=spider_name)
+        offer_id = store_offer(offer=item, spider=spider_name)
+
+        # Store page content in blob storage if present
+        if item.page_content:
+            store_page_content(offer_id, item.page_content, item.url)
+
         return item

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -63,7 +63,7 @@ def session_cosmos_db() -> Generator[CosmosClient, None, None]:
 
 @pytest.fixture(autouse=True)
 def mock_store_page_content() -> Generator[None, None, None]:
-    with patch("aerooffers.offers_db.store_page_content"):
+    with patch("aerooffers.pipelines.store_page_content"):
         yield
 
 

--- a/backend/tests/test_offers_db.py
+++ b/backend/tests/test_offers_db.py
@@ -1,5 +1,4 @@
 from datetime import date
-from unittest.mock import patch
 
 from assertpy import assert_that
 from azure.cosmos import CosmosClient
@@ -137,46 +136,3 @@ def test_should_not_store_page_content_in_offers_container(
     # then - page_content should NOT be in offers container
     offer_doc = db.offers_container().read_item(item=offer_id, partition_key=offer_id)
     assert_that(offer_doc).does_not_contain_key("page_content")
-
-
-def test_should_store_page_content_in_separate_container(
-    cosmos_db: CosmosClient,
-) -> None:
-    # given
-    test_page_content = (
-        "<html><body>Test page content for separate container</body></html>"
-    )
-    offer = sample_offer(page_content=test_page_content)
-
-    # when
-    with patch("aerooffers.offers_db.store_page_content") as mock_store:
-        offer_id = offers_db.store_offer(offer, spider="test")
-
-    # then
-    mock_store.assert_called_once_with(offer_id, test_page_content, offer.url)
-
-
-def test_should_store_offer_with_page_content_in_both_containers(
-    cosmos_db: CosmosClient,
-) -> None:
-    # given
-    test_page_content = "<html><body>Complete test content</body></html>"
-    offer = sample_offer(
-        url="https://test.com/offer",
-        title="Test Offer",
-        page_content=test_page_content,
-    )
-
-    # when
-    with patch("aerooffers.offers_db.store_page_content") as mock_store:
-        offer_id = offers_db.store_offer(offer, spider="test")
-
-    # then - offer should be in offers container without page_content
-    offer_doc = db.offers_container().read_item(item=offer_id, partition_key=offer_id)
-    assert_that(offer_doc["id"]).is_equal_to(offer_id)
-    assert_that(offer_doc["title"]).is_equal_to("Test Offer")
-    assert_that(offer_doc["url"]).is_equal_to("https://test.com/offer")
-    assert_that(offer_doc).does_not_contain_key("page_content")
-
-    # and - page_content should be stored via blob storage
-    mock_store.assert_called_once_with(offer_id, test_page_content, offer.url)


### PR DESCRIPTION
## Changes

- Move page content storage logic from offers_db to StoragePipeline
  - offers_db now only handles Cosmos DB operations
  - StoragePipeline handles blob storage operations
  - Better separation of concerns

- Move url_to_id utility to offer.py (domain code)
  - Changed from private _url_to_id to public url_to_id
  - Makes it reusable across the codebase

- Update tests to reflect new architecture
  - Update mocks to target pipelines instead of offers_db
  - Move page content storage tests to test_pipelines.py
  - Remove outdated test names referencing 'containers'